### PR TITLE
Fix releases, add dev tools, and more

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+* eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Output/
 repo/
+files/
+.vscode/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,6 +56,7 @@ notifications:
   - provider: GitHubPullRequest
     template: >
       {{#passed}}:white_check_mark:{{/passed}}{{#failed}}:x:{{/failed}} [Build {{&projectName}} {{buildVersion}} {{status}}]({{buildUrl}}) (commit {{commitUrl}} by @{{&commitAuthorUsername}})
+      {{#jobs}}{{#artifacts}}<br><b>Artifact:</b> [{{fileName}}]({{permalink}}) ({{size}} bytes){{/artifacts}}{{/jobs}}
       <p>Build messages:</p>
       <ul>
       {{#jobs}}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -72,12 +72,11 @@ artifacts:
   - path: Output\MedusaInstaller.exe
     name: MedusaInstaller.exe
 
-before_deploy:
-  - ps: |-
-      $env:ReleaseVersion = Select-String -Path .\Medusa.iss `
-        -Pattern '^#define\sMedusaInstallerVersion\s"v([\d.]+)"' | `
-        % { $($_.matches.groups[1]).Value };
+environment:
+  GH_TOKEN:
+    secure: epQRjuQ/hfy8BkTBL3NYVnmkFnsVlYEDKX5XB7RcY2Ort3Fo2sXX8LZdW+sNyRa3
 
+before_deploy:
   - ps: |-
       If ($env:InstallerVersion -ne $env:SeedVersion) `
       { `
@@ -93,14 +92,35 @@ before_deploy:
         throw "$message`n$details" `
       }
 
+  - ps: |-
+      $env:ReleaseVersion = Select-String -Path .\Medusa.iss `
+        -Pattern '^#define\sMedusaInstallerVersion\s"v([\d.]+)"' | `
+        % { $($_.matches.groups[1]).Value };
+
+  - ps: |-
+      $headers = @{
+        "Authorization" = "Bearer $env:GH_TOKEN"
+        "Content-type" = "application/json"
+      }; `
+      $LatestGitHubRelease = Invoke-RestMethod `
+        -Uri "https://api.github.com/repos/$env:APPVEYOR_REPO_NAME/releases/latest" `
+        -Headers $headers `
+        -Method GET; `
+      If ( `
+        $env:ReleaseVersion -eq $LatestGitHubRelease.tag_name `
+        -and -not $LatestGitHubRelease.draft `
+      ) { `
+        Write-Warning "Not deploying because release $env:ReleaseVersion is already published." `
+        Exit-AppveyorBuild `
+      }
+
 deploy:
   - provider: GitHub
     tag: $(ReleaseVersion)
     release: Release $(ReleaseVersion)
     force_update: true         # replaces current release
     draft: true                # release as a draft
-    auth_token:
-      secure: epQRjuQ/hfy8BkTBL3NYVnmkFnsVlYEDKX5XB7RcY2Ort3Fo2sXX8LZdW+sNyRa3
+    auth_token: $(GH_TOKEN)
     artifact: MedusaInstaller.exe
     on:
       branch: master           # release from master branch only

--- a/run_installer.cmd
+++ b/run_installer.cmd
@@ -1,0 +1,27 @@
+:: Run the installer with the local seed and external files
+
+@ECHO OFF
+
+CALL :NORMALIZEPATH "."
+SET ROOT=%RETVAL%
+SET INSTALLER="%ROOT%\Output\MedusaInstaller.exe"
+
+if not exist %INSTALLER% (
+  echo Installer not found, have you compiled the .iss file?
+  EXIT /B 1
+)
+
+:: Runs the installer with the local seed and local install files
+%INSTALLER% ^
+  /SEED="%ROOT%\seed.ini" ^
+  /LOCALFILES="%ROOT%\files" ^
+  /LOCALREPO="%ROOT%\repo" ^
+  /LOG="%ROOT%\Output\installer.log" ^
+  %*
+
+:: ========== FUNCTIONS ==========
+EXIT /B
+
+:NORMALIZEPATH
+  SET RETVAL=%~dpfn1
+  EXIT /B

--- a/seed_data.cmd
+++ b/seed_data.cmd
@@ -1,0 +1,16 @@
+:: Generate seed data for seed.ini
+
+@ECHO OFF
+
+IF NOT EXIST %1 (
+  ECHO %1 is not a valid file
+  EXIT /B 1
+)
+
+SET SIZE=%~z1
+FOR /F "tokens=*" %%i IN ('CertUtil -hashfile "%~1" SHA1 ^| find /i /v "SHA1" ^| find /i /v "certutil"') do (
+  SET SHA1=%%i
+)
+
+echo size=%SIZE%
+echo sha1=%SHA1%


### PR DESCRIPTION
- Normalize line endings
- Add local dev tools
	- Add run_installer.cmd to run the installer with the local seed and
		external files (optionally a pre-git-cloned repo, by swapping two
		lines in the [Run] section)
	- Add a small script to generate required data for the seed
- Add artifacts to notifications
- Attempt to solve deploy issue
	Where already-published releases get overriden